### PR TITLE
fix: remove unused React import and add drwxr to cspell allowlist

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -523,7 +523,8 @@
     "buildx",
     "CGNAT",
     "Metronet",
-    "myimage"
+    "myimage",
+    "drwxr"
   ],
   "dictionaries": [
     "typescript",

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import MDXComponents from '@theme-original/MDXComponents';
 import Trees from '@site/src/components/Trees';
 import Folder from '@site/src/components/Trees/Folder';


### PR DESCRIPTION
## Summary

Fixes issues found by ESLint and cspell.

### Changes
- **`src/theme/MDXComponents.js`** — removed unused `React` import (ESLint: `@typescript-eslint/no-unused-vars`)
- **`cspell.json`** — added `drwxr` to the words allowlist (appears in Unix file permission strings like `drwxr-xr-x` in the Caddy Linux install guide)