### PR TITLE
Add JellyBox music player to Jellyfin Players page

### DIFF
--- a/docs/Jellyfin Extras/Jellyfin-Players.mdx
+++ b/docs/Jellyfin Extras/Jellyfin-Players.mdx
@@ -300,6 +300,19 @@ This is not intended as a replacement for the Jellyfin Web Client. Advanced feat
 
 ---
 
+<h4>📦 JellyBox</h4>
+
+**Description:** Native desktop and mobile music client for Jellyfin. An unofficial audio client with support for lossless audio formats (FLAC) and media key controls.
+
+| Type            | Details                                                                      |
+| --------------- | ---------------------------------------------------------------------------- |
+| **Platforms**   | Windows, Linux, macOS                                                        |
+| **Downloads**   | [GitHub Releases](https://github.com/avdept/JellyBoxPlayer/releases)         |
+| **Source Code** | [GitHub Repository](https://github.com/avdept/JellyBoxPlayer)                |
+| **Type**        | Third-party Music Client                                                     |
+
+---
+
 <h3>Kodi Integration</h3>
 
 ---
@@ -437,6 +450,19 @@ This is not intended as a replacement for the Jellyfin Web Client. Advanced feat
 | **Downloads**   | [App Store](https://apps.apple.com/app/id1136220934?mt=8)    |
 | **Source Code** | [GitHub Repository](https://github.com/UnicornsOnLSD/finamp) |
 | **Type**        | Third-party Music Client                                     |
+
+---
+
+<h4>📦 JellyBox</h4>
+
+**Description:** Native mobile music client for Jellyfin with lossless audio (FLAC) support and media key controls.
+
+| Type            | Details                                                                           |
+| --------------- | --------------------------------------------------------------------------------- |
+| **Platforms**   | iPhone, iPad, macOS                                                               |
+| **Downloads**   | [App Store](https://apps.apple.com/us/app/jellybox-player/id6469732117)           |
+| **Source Code** | [GitHub Repository](https://github.com/avdept/JellyBoxPlayer)                     |
+| **Type**        | Third-party Music Client                                                          |
 
 ---
 
@@ -718,6 +744,19 @@ This is not intended as a replacement for the Jellyfin Web Client. Advanced feat
 | **Downloads**   | [GitHub Releases](https://github.com/Thomas-Sohier/jellyflut/releases) |
 | **Source Code** | [GitHub Repository](https://github.com/Thomas-Sohier/jellyflut)        |
 | **Type**        | Third-party Client                                                     |
+
+---
+
+<h4>📦 JellyBox</h4>
+
+**Description:** Native mobile music client for Jellyfin with lossless audio (FLAC) support.
+
+| Type            | Details                                                                      |
+| --------------- | ---------------------------------------------------------------------------- |
+| **Platforms**   | Android (Phone & Tablet)                                                     |
+| **Downloads**   | [APK Download](https://github.com/avdept/JellyBoxPlayer/releases)            |
+| **Source Code** | [GitHub Repository](https://github.com/avdept/JellyBoxPlayer)                |
+| **Type**        | Third-party Music Client                                                     |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **JellyBox** ([avdept/JellyBoxPlayer](https://github.com/avdept/JellyBoxPlayer)) to the Jellyfin Players documentation page.

JellyBox is a native desktop and mobile music client for Jellyfin with support for lossless audio (FLAC) and media key controls.

### Changes

- **PC Players → Music-Focused Clients**: Added JellyBox for Windows, Linux, and macOS
- **iOS/iPadOS/tvOS Players**: Added JellyBox with App Store link
- **Android Players**: Added JellyBox with APK download link

### Player Details

| | |
|---|---|
| **Platforms** | Windows, Linux, macOS, iOS, Android |
| **App Store** | https://apps.apple.com/us/app/jellybox-player/id6469732117 |
| **GitHub** | https://github.com/avdept/JellyBoxPlayer |
| **Type** | Third-party Music Client |